### PR TITLE
Java version checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Users who want to be on the bleeding edge and are prepared to take the risks of 
 
 ## Building BrailleBlaster
 
-BrailleBlaster uses the maven build system and requires a (java Development Kit of Java17 or higher to be installed. You do not need to have maven installed as BrailleBlaster includes some maven wrapper scripts which will be able to download the required version of maven. To build BrailleBlaster run the following command at the root of the source tree:
+BrailleBlaster uses the maven build system and requires a (java Development Kit of Java21 or higher to be installed. You do not need to have maven installed as BrailleBlaster includes some maven wrapper scripts which will be able to download the required version of maven. To build BrailleBlaster run the following command at the root of the source tree:
 ```command line
 mvnw package
 ```
@@ -18,7 +18,7 @@ Once the build finishes you will find the application in brailleblaster-app/targ
 
 ## Running a development build
 
-To run a development build of BrailleBlaster, either one you built yourself or from the continuous release, you will need (java17 or higher installed. On Windows or Linux issue the following command from the root of your build:
+To run a development build of BrailleBlaster, either one you built yourself or from the continuous release, you will need (java21 or higher installed. On Windows or Linux issue the following command from the root of your build:
 ```command line
 java -jar brailleblaster.jar
 ```

--- a/brailleblaster-app/pom.xml
+++ b/brailleblaster-app/pom.xml
@@ -32,6 +32,11 @@
         </dependency>
         <dependency>
             <groupId>org.brailleblaster</groupId>
+            <artifactId>brailleblaster-java-checker</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.brailleblaster</groupId>
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>

--- a/brailleblaster-java-checker/pom.xml
+++ b/brailleblaster-java-checker/pom.xml
@@ -9,7 +9,7 @@
         <version>${revision}${sha1}${changelist}</version>
     </parent>
 
-    <artifactId>brailleblaster-update-checker</artifactId>
+    <artifactId>brailleblaster-java-checker</artifactId>
 
     <dependencies>
         <dependency>
@@ -19,7 +19,11 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.platform</groupId>
-            <artifactId>org.eclipse.swt.${swt.platform}</artifactId>
+            <artifactId>org.eclipse.jface</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.swt.win32.win32.x86_64</artifactId>
             <version>${swt.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/brailleblaster-java-checker/src/main/kotlin/org/brailleblaster/javaChecker/JavaCheckerModule.kt
+++ b/brailleblaster-java-checker/src/main/kotlin/org/brailleblaster/javaChecker/JavaCheckerModule.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 Michael Whapples
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.brailleblaster.javaChecker
+
+import org.brailleblaster.BBIni
+import org.brailleblaster.perspectives.braille.Manager
+import org.brailleblaster.perspectives.mvc.BBSimpleManager.SimpleListener
+import org.brailleblaster.perspectives.mvc.SimpleEvent
+import org.brailleblaster.perspectives.mvc.events.AppStartedEvent
+import org.brailleblaster.spi.ModuleFactory
+import org.brailleblaster.userHelp.VersionInfo
+import org.eclipse.jface.dialogs.MessageDialogWithToggle
+import org.eclipse.swt.widgets.Display
+
+object JavaCheckerModule : SimpleListener {
+    override fun onEvent(event: SimpleEvent) {
+        if (event is AppStartedEvent) {
+            val minVersion = Runtime.Version.parse("21")
+            val jvmVersion = Runtime.version()
+            val propManager = BBIni.propertyFileManager
+            val warnVersion = maxOf(jvmVersion, Runtime.Version.parse(propManager.getProperty("javaChecker.warn.version", "11")))
+            if (warnVersion < minVersion) {
+                val result = MessageDialogWithToggle.openWarning(Display.getCurrent()?.activeShell, "Outdated Java", "Your Java runtime is no longer supported by ${VersionInfo.Project.BB.displayName} and may in the future fail to run this software. Please update to at least Java ${minVersion}.", "Do not show this warning again", false, null, null)
+                if (result.toggleState) {
+                    propManager.save("javaChecker.warn.version", minVersion.toString())
+                }
+            }
+        }
+    }
+}
+
+class JavaCheckerModuleFactory() : ModuleFactory {
+    override fun createModules(manager: Manager): Iterable<SimpleListener> = listOf(JavaCheckerModule)
+}

--- a/brailleblaster-java-checker/src/main/resources/META-INF/services/org.brailleblaster.spi.ModuleFactory
+++ b/brailleblaster-java-checker/src/main/resources/META-INF/services/org.brailleblaster.spi.ModuleFactory
@@ -1,0 +1,1 @@
+org.brailleblaster.javaChecker.JavaCheckerModuleFactory

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <module>xom-utils</module>
         <module>brailleblaster-exceptions</module>
         <module>brailleblaster-update-checker</module>
+        <module>brailleblaster-java-checker</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This change performs a check of the Java runtime and warns the user if they are using a version which is planned to be dropped from BrailleBlaster. This only really affects those users who run the continuous build or have built their own from source, the binary builds with conveyor contain their own Java runtime so should always have a suitable JVM.