### PR TITLE
Fix an issue where ASCIIMath hub would not open due to missing logger

### DIFF
--- a/brailleblaster-app/pom.xml
+++ b/brailleblaster-app/pom.xml
@@ -19,6 +19,10 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.brailleblaster</groupId>
             <artifactId>brailleblaster-core</artifactId>
             <version>${project.version}</version>

--- a/brailleblaster-core/pom.xml
+++ b/brailleblaster-core/pom.xml
@@ -132,11 +132,6 @@
             <artifactId>jeuclid-core</artifactId>
             <version>${jeuclid.version}</version>
             <exclusions>
-                <!-- Use jcl-over-slf4j -->
-                <exclusion>
-                    <artifactId>commons-logging</artifactId>
-                    <groupId>commons-logging</groupId>
-                </exclusion>
                 <exclusion>
                     <artifactId>commons-io</artifactId>
                     <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -435,8 +435,19 @@ child.project.url.inherit.append.path="false">
                 <version>${guava.version}</version>
             </dependency>
             <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>1.3.5</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
The ASCIIMath Hub was failing to open due to a missing logging dependency, this change adds that required dependency.