### PR TITLE
Fix issue with error reporting due to missing parameter

### DIFF
--- a/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/mvc/modules/misc/ExceptionReportingModule.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/mvc/modules/misc/ExceptionReportingModule.kt
@@ -194,6 +194,7 @@ object ExceptionReportingModule /*implements SimpleListener*/ {
                 .put("exception", ExceptionUtils.getStackTrace(exception))
                 .put("description", description ?: "")
                 .put("versionBb", Project.BB.version)
+                .put("versionUtd", "Unknown")
                 .put("versionJLouis", "Unknown")
                 .put(
                     "versionLibLouis",


### PR DESCRIPTION
All error report submissions were failing due to a missing parameter, this fix solves this. The missing parameter is versionUtd, but as UTD is no longer separately versioned we just set this to Unknown.