### PR TITLE
Fix opening word documents on Linux and Mac

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,9 +39,7 @@ jobs:
       run: brailleblaster-app/scripts/get-docs.sh brailleblaster-app/target/dist/docs
     - name: Zip distribution
       run: |
-        mkdir brailleblaster-continuous
-        cp -R -t brailleblaster-continuous brailleblaster-app/target/dist/*
-        zip -r brailleblaster-continuous.zip brailleblaster-continuous
+        zip -r brailleblaster-continuous.zip brailleblaster-app/target/dist/*
     - name: Upload dist
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -62,7 +62,6 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: brailleblaster
-        path: brailleblaster-continuous.zip
     - name: Update continuous tag
       uses: actions/github-script@v7
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,6 +44,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: brailleblaster
+        path: brailleblaster-continuous.zip
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
       if: github.ref == 'ref/heads/main' && github.event_name != 'pull_request'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,7 +37,10 @@ jobs:
         mvn -B install --file pom.xml -DskipTests -Drevision=${{ env.BB_VERSION }} -Dsha1=-${{ github.sha }} -Dchangelist=${{ env.BB_CHANGELIST }}
     - name: Get docs
       run: brailleblaster-app/scripts/get-docs.sh brailleblaster-app/target/dist/docs
-
+    - name: Zip distribution
+      run: |
+        cp -R -t brailleblaster-continuous brailleblaster-app/target/dist/*
+        zip -r brailleblaster-continuous.zip brailleblaster-continuous
     - name: Upload dist
       uses: actions/upload-artifact@v4
       with:
@@ -62,9 +65,6 @@ jobs:
       with:
         name: brailleblaster
         path: brailleblaster-continuous
-    - name: Zip distribution
-      run: |
-        zip -r brailleblaster-continuous.zip brailleblaster-continuous
     - name: Update continuous tag
       uses: actions/github-script@v7
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         mkdir brailleblaster-continuous
         cp -a -t brailleblaster-continuous brailleblaster-app/target/dist/*
-        zip -r brailleblaster-continuous.zip brailleblaster-app/target/dist/*
+        zip -r brailleblaster-continuous.zip brailleblaster-continuous
     - name: Upload dist
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,6 +39,7 @@ jobs:
       run: brailleblaster-app/scripts/get-docs.sh brailleblaster-app/target/dist/docs
     - name: Zip distribution
       run: |
+        mkdir brailleblaster-continuous
         cp -R -t brailleblaster-continuous brailleblaster-app/target/dist/*
         zip -r brailleblaster-continuous.zip brailleblaster-continuous
     - name: Upload dist

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,8 +45,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: brailleblaster
-        path: brailleblaster-app/target/dist
-
+        path: brailleblaster-continuous.zip
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
       if: github.ref == 'ref/heads/main' && github.event_name != 'pull_request'
@@ -64,7 +63,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: brailleblaster
-        path: brailleblaster-continuous
+        path: brailleblaster-continuous.zip
     - name: Update continuous tag
       uses: actions/github-script@v7
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,7 +44,6 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: brailleblaster
-        path: brailleblaster-continuous.zip
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
       if: github.ref == 'ref/heads/main' && github.event_name != 'pull_request'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,6 +39,8 @@ jobs:
       run: brailleblaster-app/scripts/get-docs.sh brailleblaster-app/target/dist/docs
     - name: Zip distribution
       run: |
+        mkdir brailleblaster-continuous
+        cp -a -t brailleblaster-continuous brailleblaster-app/target/dist/*
         zip -r brailleblaster-continuous.zip brailleblaster-app/target/dist/*
     - name: Upload dist
       uses: actions/upload-artifact@v4

--- a/brailleblaster-app/pom.xml
+++ b/brailleblaster-app/pom.xml
@@ -147,7 +147,6 @@
                                 <org.codehaus.plexus.components.io.filemappers.FlattenFileMapper/>
                             </fileMappers>
                             <outputDirectory>${build.dist.native.directory}/windows-x86_64/bin</outputDirectory>
-                            <outputFilePermissions>+x</outputFilePermissions>
                         </configuration>
                     </execution>
                     <execution>
@@ -166,7 +165,6 @@
                                 <org.codehaus.plexus.components.io.filemappers.FlattenFileMapper/>
                             </fileMappers>
                             <outputDirectory>${build.dist.native.directory}/linux-x86_64/bin</outputDirectory>
-                            <outputFilePermissions>+x</outputFilePermissions>
                         </configuration>
                     </execution>
                     <execution>
@@ -185,7 +183,6 @@
                                 <org.codehaus.plexus.components.io.filemappers.FlattenFileMapper/>
                             </fileMappers>
                             <outputDirectory>${build.dist.native.directory}/linux-aarch64/bin</outputDirectory>
-                            <outputFilePermissions>+x</outputFilePermissions>
                         </configuration>
                     </execution>
                     <execution>
@@ -204,7 +201,6 @@
                                 <org.codehaus.plexus.components.io.filemappers.FlattenFileMapper/>
                             </fileMappers>
                             <outputDirectory>${build.dist.native.directory}/mac-x86_64/bin</outputDirectory>
-                            <outputFilePermissions>+x</outputFilePermissions>
                         </configuration>
                     </execution>
                     <execution>
@@ -223,7 +219,6 @@
                                 <org.codehaus.plexus.components.io.filemappers.FlattenFileMapper/>
                             </fileMappers>
                             <outputDirectory>${build.dist.native.directory}/mac-aarch64/bin</outputDirectory>
-                            <outputFilePermissions>+x</outputFilePermissions>
                         </configuration>
                     </execution>
                 </executions>

--- a/brailleblaster-app/pom.xml
+++ b/brailleblaster-app/pom.xml
@@ -147,6 +147,7 @@
                                 <org.codehaus.plexus.components.io.filemappers.FlattenFileMapper/>
                             </fileMappers>
                             <outputDirectory>${build.dist.native.directory}/windows-x86_64/bin</outputDirectory>
+                            <outputFilePermissions>+x</outputFilePermissions>
                         </configuration>
                     </execution>
                     <execution>
@@ -165,6 +166,7 @@
                                 <org.codehaus.plexus.components.io.filemappers.FlattenFileMapper/>
                             </fileMappers>
                             <outputDirectory>${build.dist.native.directory}/linux-x86_64/bin</outputDirectory>
+                            <outputFilePermissions>+x</outputFilePermissions>
                         </configuration>
                     </execution>
                     <execution>
@@ -183,6 +185,7 @@
                                 <org.codehaus.plexus.components.io.filemappers.FlattenFileMapper/>
                             </fileMappers>
                             <outputDirectory>${build.dist.native.directory}/linux-aarch64/bin</outputDirectory>
+                            <outputFilePermissions>+x</outputFilePermissions>
                         </configuration>
                     </execution>
                     <execution>
@@ -201,6 +204,7 @@
                                 <org.codehaus.plexus.components.io.filemappers.FlattenFileMapper/>
                             </fileMappers>
                             <outputDirectory>${build.dist.native.directory}/mac-x86_64/bin</outputDirectory>
+                            <outputFilePermissions>+x</outputFilePermissions>
                         </configuration>
                     </execution>
                     <execution>
@@ -219,6 +223,7 @@
                                 <org.codehaus.plexus.components.io.filemappers.FlattenFileMapper/>
                             </fileMappers>
                             <outputDirectory>${build.dist.native.directory}/mac-aarch64/bin</outputDirectory>
+                            <outputFilePermissions>+x</outputFilePermissions>
                         </configuration>
                     </execution>
                 </executions>

--- a/brailleblaster-core/src/main/java/org/brailleblaster/BBIniImpl.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/BBIniImpl.kt
@@ -31,8 +31,9 @@ import kotlin.io.path.Path
 
 class BBIniImpl(val bbDistPath: Path, bbUserPath: Path, propManager: PropertyFileManager?, debugArgs: List<String>) {
     private val log: Logger = LoggerFactory.getLogger(javaClass)
-    val nativeBinPath: Path = bbDistPath.resolve(Path("native", "$os-$arch", "bin"))
-    val nativeLibraryPath: Path = bbDistPath.resolve(Path("native", "${os}-${arch}", "lib"))
+    private val nativePath: Path = bbDistPath.resolve(Path("native", "$os-$arch".lowercase()))
+    val nativeBinPath: Path = nativePath.resolve("bin")
+    val nativeLibraryPath: Path = nativePath.resolve("lib")
     val nativeLibrarySuffix = when(os) {
         OS.Windows -> ".dll"
         OS.Mac -> ".dylib"


### PR DESCRIPTION
The native path was broken on any platform which uses a case sensitive filesystem such as Linux and Mac. This meant that importing files which need the use of pandoc would fail with an error.