### PR TITLE
Install fonts on debian based linux.

### DIFF
--- a/brailleblaster-app/src/dist/conveyor.conf
+++ b/brailleblaster-app/src/dist/conveyor.conf
@@ -47,6 +47,14 @@ app {
   icons = "icon.png"
   file-associations = [ .bbz ]
   linux {
+    root-inputs += {
+      from = "programData/fonts"
+      to = "/usr/share/fonts/opentype/"
+      remap = [ "*.otf" ]
+    }
+    debian.postinst = ${app.linux.debian.postinst}"""
+      fc-cache -f -v
+    """
     desktop-file."Desktop Entry".Categories = "GTK;Office;"
     amd64.glibc {
       inputs += "native/linux-x86_64/lib/*.jar"


### PR DESCRIPTION
The debian packages will now install the Braille fonts.