### PR TITLE
Pass JVM system property to prevent engine interpreter mode being used.

### DIFF
--- a/brailleblaster-app/src/dist/conveyor.conf
+++ b/brailleblaster-app/src/dist/conveyor.conf
@@ -39,6 +39,7 @@ app {
     system-properties {
       jlouis.library.path = <libpath>
       mathcat.library.path = <libpath>
+      polyglot.engine.WarnInterpreterOnly = false
     }
     linux.options += "-Dtruffle.attach.library="<libpath>"/libtruffleattach.so"
     mac.options += "-Dtruffle.attach.library="<libpath>"/libtruffleattach.dylib"


### PR DESCRIPTION
Java issues a warning when translating math. The warning relates to the JS engine working in interpreter mode. We are intentionally using interpreter mode.