### PR TITLE
Fix issue with BRF, Braille preview and embossing

### DIFF
--- a/utd/src/main/java/org/brailleblaster/utd/BRFWriter.java
+++ b/utd/src/main/java/org/brailleblaster/utd/BRFWriter.java
@@ -428,9 +428,8 @@ public class BRFWriter {
 
         public Collection<PageEntry> getEntryAtPos(int cell, int line) {
             final Point point = new Point(cell, line);
-            Collection<PageEntry> entries = pages.getOrDefault(point, new ArrayList<>());
-            pages.remove(point);
-            return entries;
+            Collection<PageEntry> entries = pages.remove(point);
+            return entries == null ? new ArrayList<>() : entries;
         }
 
         public void onAfterFlush(BRFWriter brfWriter) {


### PR DESCRIPTION
This fixes an issue where save as BRF, Braille preview and embossing may fail with an exception. This issue is in BRFWriter and so could affect any component using that.