### PR TITLE
Install fonts in app specific directory

### DIFF
--- a/brailleblaster-app/src/dist/conveyor.conf
+++ b/brailleblaster-app/src/dist/conveyor.conf
@@ -50,7 +50,7 @@ app {
   linux {
     root-inputs += {
       from = "programData/fonts"
-      to = "/usr/share/fonts/opentype/"
+      to = "/usr/share/fonts/opentype/${app.vendor-fsname}/${app.fsname}"
       remap = [ "*.otf" ]
     }
     debian.postinst = ${app.linux.debian.postinst}"""


### PR DESCRIPTION
This changes BrailleBlaster to install fonts in an app specific directory and so should help avoid clashes with any other forks.