### PR TITLE
Add stub metadata to exported eBraille.

### DIFF
--- a/brailleblaster-ebraille/src/main/kotlin/org/brailleblaster/ebraille/OpfUtils.kt
+++ b/brailleblaster-ebraille/src/main/kotlin/org/brailleblaster/ebraille/OpfUtils.kt
@@ -22,13 +22,51 @@ import org.brailleblaster.utils.xml.DC_NS
 import org.brailleblaster.utils.xml.OPF_NS
 import java.io.OutputStream
 import java.net.URL
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
+@OptIn(ExperimentalUuidApi::class)
 fun createOpf(items: List<PackageItem>): Document = Document(Element("package", OPF_NS).apply {
     val itemMap = items.mapIndexed { i, item -> "file${i}" to item }.toMap()
     addNamespaceDeclaration("dc", DC_NS)
     addAttribute(Attribute("version", "3.0"))
     addAttribute(Attribute("unique-identifier", "bookid"))
-    appendChild(Element("metadata", OPF_NS))
+    appendChild(Element("metadata", OPF_NS).apply {
+        val nowDateTime = LocalDateTime.now(Clock.systemUTC()).truncatedTo(ChronoUnit.SECONDS)
+        appendChild(Element("dc:format", DC_NS).apply {
+            appendChild("1.0")
+        })
+        appendChild(Element("dc:date", DC_NS).apply {
+            appendChild(DateTimeFormatter.ISO_LOCAL_DATE.format(nowDateTime))
+        })
+        appendChild(createMetaProperty("dcterms:modified", DateTimeFormatter.ISO_INSTANT.format(nowDateTime.toInstant(ZoneOffset.UTC))))
+        appendChild(createMetaProperty("a11y:tactileGraphics", "false"))
+        appendChild(Element("dc:identifier", DC_NS).apply {
+            appendChild(Uuid.generateV4().toHexDashString())
+        })
+        appendChild(Element("dc:title", DC_NS).apply {
+            appendChild("-")
+        })
+        appendChild(Element("dc:creator", DC_NS).apply {
+            appendChild("-")
+        })
+        appendChild(createMetaProperty("a11y:producer", "-"))
+        appendChild(Element("dc:language", DC_NS).apply {
+            appendChild("en-Brai")
+        })
+        appendChild(createMetaProperty("a11y:brailleSystem", "UEB"))
+        appendChild(createMetaProperty("a11y:cellType", "6"))
+        appendChild(createMetaProperty("a11y:completeTranscription", "true"))
+        val dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        val defaultInstant = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC).format(dtf)
+        appendChild(createMetaProperty("dcterms:dateCopyrighted", defaultInstant))
+        appendChild(createMetaProperty("a11y:dateTranscribed", defaultInstant))
+    })
     appendChild(Element("manifest", OPF_NS).apply {
         for ((id, item) in itemMap) {
             appendChild(Element("item", OPF_NS).apply {
@@ -71,4 +109,9 @@ data class ResourceItem(override val path: String, val resourceUrl: URL, overrid
     override fun write(output: OutputStream) {
         resourceUrl.openStream().use { it.copyTo(output) }
     }
+}
+
+private fun createMetaProperty(name: String, value: String): Element = Element("meta", OPF_NS).apply {
+    addAttribute(Attribute("property", name))
+    appendChild(value)
 }


### PR DESCRIPTION
Metadata is required for an eBraille file to be valid. This adds some stub metadata simply to make the eBraille valid. This does not let the user specify the metadata.