### PR TITLE
Fixed deleting text crash bug.

### DIFF
--- a/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/braille/views/wp/TextRenderer.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/braille/views/wp/TextRenderer.kt
@@ -211,7 +211,7 @@ class TextRenderer(manager: Manager, private val textView: TextView) : Renderer(
                                 if (indexes != null) {
                                     //Do not render anything that comes before this, but update
                                     //the indexes appropriately
-                                    end = indexes[totalLength - 1] + 1
+                                    end = minOf(indexes[totalLength - 1] + 1, t.node.value.length)
                                     //Add nonrendered portion to the invisible text of the TME
                                     if (totalLength == indexes.size) {
                                         t.appendInvisibleText(t.node.value.substring(start))
@@ -280,7 +280,7 @@ class TextRenderer(manager: Manager, private val textView: TextView) : Renderer(
                                     firstText = false
                                 }
                                 //Find what this brl text node is in the print text node
-                                end = indexes[totalLength - 1] + 1
+                                end = minOf(indexes[totalLength - 1] + 1, t.node.value.length)
                                 val lineContent = if (totalLength == indexes.size) {
                                     t.node.value.substring(start)
                                 } else {


### PR DESCRIPTION
In some cases for example after a
merge/backspace operation that changes the document structure indexes[totalLength - 1] + 1` produced a value (692) that exceeded the actual length of the print text node string (690), causing `substring(start, end)` to throw the exception.

This problem existed in two places:

1. The pastFirstNewPage code building invisible text for off-page content
2. The normal visible-text rendering code

Both seem to be fixed.