### PR TITLE
Fix text insertion at page breaks and add Page Break marker

### DIFF
--- a/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/braille/stylers/WhitespaceTransformer.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/braille/stylers/WhitespaceTransformer.kt
@@ -32,17 +32,22 @@ import org.brailleblaster.math.template.Template.Companion.isTemplate
 import org.brailleblaster.perspectives.braille.Manager
 import org.brailleblaster.perspectives.braille.mapping.elements.BoxLineTextMapElement
 import org.brailleblaster.perspectives.braille.mapping.elements.LineBreakElement
+import org.brailleblaster.perspectives.braille.mapping.elements.PageBreakWhiteSpaceElement
 import org.brailleblaster.perspectives.braille.mapping.elements.WhiteSpaceElement
 import org.brailleblaster.perspectives.braille.messages.Sender
 import org.brailleblaster.perspectives.braille.messages.WhitespaceMessage
 import org.brailleblaster.perspectives.mvc.XMLTextCaret
 import org.brailleblaster.perspectives.mvc.events.XMLCaretEvent
+import org.brailleblaster.util.LINE_BREAK
 import org.brailleblaster.util.WhitespaceUtils.appendLineBreakElement
 import org.brailleblaster.util.WhitespaceUtils.prependLineBreakElement
 import org.brailleblaster.util.WhitespaceUtils.removeLineBreakElements
 
 class WhitespaceTransformer(manager: Manager) : Handler(manager, manager.viewInitializer, manager.mapList) {
+    private var pendingCursorOffset: Int = -1
+
     fun transformWhiteSpace(message: WhitespaceMessage) {
+        pendingCursorOffset = message.offset
         //if(isInline(list.getCurrent()))
         //	transformInlineText((WhiteSpaceElement)list.get(message.getIndex()), message.getNewText());
         //else
@@ -71,6 +76,33 @@ class WhitespaceTransformer(manager: Manager) : Handler(manager, manager.viewIni
 
         if (wse is LineBreakElement && !atBeginning) {
             blankLinesBefore-- //An extra line break element is added to the previous tme
+        }
+
+        // When typing within a PageBreakWhiteSpaceElement, the entire blank page area is
+        // represented by a single maplist entry, so the maplist-index-based blankLinesBefore
+        // is always 1.  Override it with the actual visual distance from the previous text
+        // element to the cursor so that the correct number of blank lines is inserted before
+        // the new text.
+        if (wse is PageBreakWhiteSpaceElement && pendingCursorOffset >= 0 && !atBeginning && curElement != null) {
+            val view = manager.text.view
+            // curElement.getEnd(list) is the charCount at the moment curElement finished
+            // rendering, which equals the widget offset of the '\r' that terminates
+            // curElement's own line.  getLineAtOffset() of that position returns
+            // curElement's line number.
+            //
+            // The number of NEW_LINE elements needed to place text at the cursor's visual
+            // line is exactly (cursorLine - curElementLine), so we use curElement.getEnd()
+            // directly as the reference point rather than curElement.getEnd() + LINE_BREAK
+            // (which would point to the start of the NEXT line and undercount by 1).
+            val pbStart = curElement.getEnd(list)
+            if (view.charCount > 0 && pbStart >= 0 && pbStart < view.charCount) {
+                val pbStartLine = view.getLineAtOffset(pbStart)
+                val cursorLine = view.getLineAtOffset(pendingCursorOffset.coerceIn(0, view.charCount - 1))
+                val visualBlankLines = cursorLine - pbStartLine
+                if (visualBlankLines > blankLinesBefore) {
+                    blankLinesBefore = visualBlankLines
+                }
+            }
         }
 
         if (nextElement != null) { //nextElement is null at the end of the document

--- a/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/braille/views/style/StylePane.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/perspectives/braille/views/style/StylePane.kt
@@ -22,6 +22,7 @@ import org.brailleblaster.easierxml.ImageUtils.getImageNavigateBlock
 import org.brailleblaster.math.mathml.MathModuleUtils
 import org.brailleblaster.perspectives.braille.Manager
 import org.brailleblaster.perspectives.braille.mapping.elements.BraillePageBrlMapElement
+import org.brailleblaster.perspectives.braille.mapping.elements.PageBreakWhiteSpaceElement
 import org.brailleblaster.perspectives.braille.mapping.elements.PageIndicator
 import org.brailleblaster.perspectives.braille.mapping.maps.MapList
 import org.brailleblaster.perspectives.braille.mapping.maps.PaintedElementsList
@@ -97,6 +98,16 @@ class StylePane(parent: Composite, private val m: Manager) : BBEditorView {
                     textMapElement.node
                 )
             )
+            if (textMapElement is PageBreakWhiteSpaceElement) {
+                val pbEnd = textMapElement.getEnd(mapList)
+                if (pbEnd >= 0 && pbEnd <= textViewWidget.charCount) {
+                    val pbLine = textViewWidget.getLineAtOffset(pbEnd)
+                    if (!lines.containsKey(pbLine)) {
+                        lines[pbLine] = "Page Break"
+                    }
+                }
+                continue
+            }
             if (textMapElement.node == null) {
                 log.trace("skipping null node")
                 continue


### PR DESCRIPTION
This makes it easy to add text before page breaks and it works more like a normal word processor.  I also went back after fixing this and added the page break in the style view because it was in the issue.