### PR TITLE
Fix issue with OPF, spine should contain itemref elements instead of item elements

### DIFF
--- a/brailleblaster-ebraille/src/main/kotlin/org/brailleblaster/ebraille/OpfUtils.kt
+++ b/brailleblaster-ebraille/src/main/kotlin/org/brailleblaster/ebraille/OpfUtils.kt
@@ -79,7 +79,7 @@ fun createOpf(items: List<PackageItem>): Document = Document(Element("package", 
     })
     appendChild(Element("spine", OPF_NS).apply {
         for (id in itemMap.filterValues { it.includeInSpine }.keys) {
-            appendChild(Element("item", OPF_NS).apply {
+            appendChild(Element("itemref", OPF_NS).apply {
                 addAttribute(Attribute("idref", id))
             })
         }


### PR DESCRIPTION
The spine is meant to be a list of itemref elements. We were previously incorrectly using item elements which lead to the OPF failing to be processed by epub readers.