### PR TITLE
Change to using XML syntax for XHTML files.

### DIFF
--- a/brailleblaster-ebraille/src/main/kotlin/org/brailleblaster/ebraille/EBraillePackager.kt
+++ b/brailleblaster-ebraille/src/main/kotlin/org/brailleblaster/ebraille/EBraillePackager.kt
@@ -35,8 +35,8 @@ object EBraillePackager {
         }
     }
     fun createEbraillePackage(outPath: Path, docs: List<Document>, title: String = "-", translationEngine: ITranslationEngine = UTDTranslationEngine()) {
-        val docItems = docs.mapIndexed { i, doc -> HtmlItem("ebraille/document${i}.html", doc) }
-        val navDoc = HtmlItem("index.html", NavigationHtml.createNavigationHtml(docItems, title = title, translationEngine = translationEngine), properties = "nav")
+        val docItems = docs.mapIndexed { i, doc -> XHtmlItem("ebraille/document${i}.html", doc) }
+        val navDoc = XHtmlItem("index.html", NavigationHtml.createNavigationHtml(docItems, title = title, translationEngine = translationEngine), properties = "nav")
         packageDocument(outPath, docItems + RESOURCE_ITEMS + navDoc)
     }
     private fun packageDocument(outPath: Path, packageItems: List<PackageItem>) {

--- a/brailleblaster-ebraille/src/main/kotlin/org/brailleblaster/ebraille/NavigationHtml.kt
+++ b/brailleblaster-ebraille/src/main/kotlin/org/brailleblaster/ebraille/NavigationHtml.kt
@@ -41,7 +41,7 @@ object NavigationHtml {
             <body></body>
             </html>
         """.trimIndent()
-    fun createNavigationHtml(docs: Iterable<HtmlItem>, title: String, translationEngine: ITranslationEngine): Document {
+    fun createNavigationHtml(docs: Iterable<XHtmlItem>, title: String, translationEngine: ITranslationEngine): Document {
         val titleBrl: String = translateToBraille(title, translationEngine)
         val template = javaClass.getResourceAsStream("/org/brailleblaster/ebraille/index_template.html")?.bufferedReader(Charsets.UTF_8)?.readText() ?: FALLBACK_TEMPLATE
         val html = Jsoup.parse(template)
@@ -51,7 +51,7 @@ object NavigationHtml {
         html.body().appendChild(createPageList(docs, headingBrl = translateToBraille("List of pages", translationEngine)))
         return html
     }
-    private fun createHeadingsList(docs: Iterable<HtmlItem>, headingBrl: String = "⠠⠞⠁⠼ ⠷ ⠒⠞⠢⠞⠎"): Element = Element("nav").attr("role", "doc-toc").attr("aria-label", "Contents").attr("epub:type", "toc").appendChild(Element("h2").appendText(headingBrl)).apply {
+    private fun createHeadingsList(docs: Iterable<XHtmlItem>, headingBrl: String = "⠠⠞⠁⠼ ⠷ ⠒⠞⠢⠞⠎"): Element = Element("nav").attr("role", "doc-toc").attr("aria-label", "Contents").attr("epub:type", "toc").appendChild(Element("h2").appendText(headingBrl)).apply {
         val idGenerator = IdGenerator()
         val headings = docs.flatMap { doc -> doc.document.select(HEADINGS_LEVEL_MAP.keys.joinToString(separator = ", ")).map {
             if (it.id().isEmpty()) {
@@ -61,7 +61,7 @@ object NavigationHtml {
         } }
         appendChild(headings.toHtml(level = 0, containerFactory = { Element("ol") }, itemFactory = { listOf(Element("li").appendChild(Element("a").attr("href", "${it.element.path}#${it.element.element.id()}").appendText(it.element.element.text()))) }))
     }
-    private fun createPageList(docs: Iterable<HtmlItem>, headingBrl: String = "⠠⠇⠊⠌ ⠷ ⠏⠁⠛⠑⠎"): Element = Element("nav").attr("role", "doc-pagelist").attr("epub:type", "page-list").attr("aria-label", "Page list").attr("hidden", "").appendChild(Element("h2").appendText(headingBrl)).apply {
+    private fun createPageList(docs: Iterable<XHtmlItem>, headingBrl: String = "⠠⠇⠊⠌ ⠷ ⠏⠁⠛⠑⠎"): Element = Element("nav").attr("role", "doc-pagelist").attr("epub:type", "page-list").attr("aria-label", "Page list").attr("hidden", "").appendChild(Element("h2").appendText(headingBrl)).apply {
         val idGenerator = IdGenerator()
         val pages = docs.flatMap { doc -> doc.document.select("""span[role="doc-pagebreak"]""").map {
             if (it.id().isEmpty()) {

--- a/brailleblaster-ebraille/src/main/kotlin/org/brailleblaster/ebraille/OpfUtils.kt
+++ b/brailleblaster-ebraille/src/main/kotlin/org/brailleblaster/ebraille/OpfUtils.kt
@@ -94,12 +94,12 @@ interface PackageItem {
     fun write(output: OutputStream)
 }
 
-data class HtmlItem(override val path: String, val document: org.jsoup.nodes.Document, override val includeInSpine: Boolean = true,
-                    override val properties: String? = null) : PackageItem {
+data class XHtmlItem(override val path: String, val document: org.jsoup.nodes.Document, override val includeInSpine: Boolean = true,
+                     override val properties: String? = null) : PackageItem {
     override val mediaType: String = "application/xhtml+xml"
     override fun write(output: OutputStream) {
         output.bufferedWriter(Charsets.UTF_8).also {
-            document.html(it)
+            document.outputSettings(document.outputSettings().syntax(org.jsoup.nodes.Document.OutputSettings.Syntax.xml)).html(it)
         }.flush()
     }
 }


### PR DESCRIPTION
As the HTML files are given a XHTML mimetype in the OPF these files must follow the XML syntax. This ensures the correct syntax is used.