### PR TITLE
Migrate startup arg parsing to Apache Commons CLI

### DIFF
--- a/brailleblaster-core/pom.xml
+++ b/brailleblaster-core/pom.xml
@@ -32,6 +32,11 @@
     
     <dependencies>
         <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.10.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.aphtech.libembosser</groupId>
             <artifactId>libembosser-api</artifactId>
         </dependency>

--- a/brailleblaster-core/pom.xml
+++ b/brailleblaster-core/pom.xml
@@ -34,7 +34,6 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.10.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.aphtech.libembosser</groupId>

--- a/brailleblaster-core/src/main/java/org/brailleblaster/AppProperties.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/AppProperties.kt
@@ -15,26 +15,60 @@
  */
 package org.brailleblaster
 
+import org.brailleblaster.utils.BBData
+import java.nio.file.Path
 import java.util.Properties
+import kotlin.io.path.exists
 import kotlin.io.path.reader
 
 object AppProperties {
-    private val properties: Properties = Properties().apply {
+    private const val ABOUT_PROPERTIES = "about.properties"
+
+    private fun loadProperties(): Properties {
+        val properties = Properties()
+        val candidatePaths = linkedSetOf<Path>()
+
         runCatching {
-            BBIni.bbDistPath.resolve("about.properties").reader(Charsets.UTF_8).use { load(it) }
+            candidatePaths.add(BBIni.bbDistPath.resolve(ABOUT_PROPERTIES))
         }
+        candidatePaths.add(BBData.brailleblasterPath.toPath().resolve(ABOUT_PROPERTIES))
+
+        for (path in candidatePaths) {
+            if (!path.exists()) {
+                continue
+            }
+            runCatching {
+                path.reader(Charsets.UTF_8).use { properties.load(it) }
+                return properties
+            }
+        }
+
+        return properties
     }
-    val displayName = properties.getProperty("app.display-name") ?: "BrailleBlaster"
-    val description = properties.getProperty("app.description") ?: displayName
-    val version = properties.getProperty("app.version") ?: "Unknown"
-    val vendor = properties.getProperty("app.vendor") ?: "Unknown"
-    val buildDate = properties.getProperty("app.build-date") ?: "Unknown"
+
+    private fun property(name: String): String? = loadProperties().getProperty(name)
+
+    val displayName: String
+        get() = property("app.display-name") ?: "BrailleBlaster"
+    val description: String
+        get() = property("app.description") ?: displayName
+    val version: String
+        get() = property("app.version") ?: "Unknown"
+    val vendor: String
+        get() = property("app.vendor") ?: "Unknown"
+    val buildDate: String
+        get() = property("app.build-date") ?: "Unknown"
     @Suppress("Unused")
-    val fsname = properties.getProperty("app.fsname") ?: "brailleblaster"
-    val buildHash: String? = properties.getProperty("app.build-hash")
+    val fsname: String
+        get() = property("app.fsname") ?: "brailleblaster"
+    val buildHash: String?
+        get() = property("app.build-hash")
     @Suppress("Unused")
-    val vcsUrl = properties.getProperty("app.vcs-url") ?: "https://github.com/aphtech/brailleblaster"
+    val vcsUrl: String
+        get() = property("app.vcs-url") ?: "https://github.com/aphtech/brailleblaster"
     @Suppress("Unused")
-    val downloadUrl = properties.getProperty("app.site.base-url") ?: "https://github.com/aphtech/brailleblaster/releases/latest"
-    val websiteUrl = properties.getProperty("app.website-url") ?: "https://www.brailleblaster.org"
+    val downloadUrl: String
+        get() = property("app.site.base-url") ?: "https://github.com/aphtech/brailleblaster/releases/latest"
+    val websiteUrl: String
+        get() = property("app.website-url") ?: "https://www.brailleblaster.org"
 }

--- a/brailleblaster-core/src/main/java/org/brailleblaster/AppProperties.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/AppProperties.kt
@@ -16,59 +16,27 @@
 package org.brailleblaster
 
 import org.brailleblaster.utils.BBData
-import java.nio.file.Path
 import java.util.Properties
-import kotlin.io.path.exists
+import kotlin.io.path.absolute
 import kotlin.io.path.reader
 
 object AppProperties {
-    private const val ABOUT_PROPERTIES = "about.properties"
-
-    private fun loadProperties(): Properties {
-        val properties = Properties()
-        val candidatePaths = linkedSetOf<Path>()
-
+    private val properties: Properties = Properties().apply {
         runCatching {
-            candidatePaths.add(BBIni.bbDistPath.resolve(ABOUT_PROPERTIES))
+            BBData.brailleblasterPath.toPath().absolute().resolve("about.properties").reader(Charsets.UTF_8).use { load(it) }
         }
-        candidatePaths.add(BBData.brailleblasterPath.toPath().resolve(ABOUT_PROPERTIES))
-
-        for (path in candidatePaths) {
-            if (!path.exists()) {
-                continue
-            }
-            runCatching {
-                path.reader(Charsets.UTF_8).use { properties.load(it) }
-                return properties
-            }
-        }
-
-        return properties
     }
-
-    private fun property(name: String): String? = loadProperties().getProperty(name)
-
-    val displayName: String
-        get() = property("app.display-name") ?: "BrailleBlaster"
-    val description: String
-        get() = property("app.description") ?: displayName
-    val version: String
-        get() = property("app.version") ?: "Unknown"
-    val vendor: String
-        get() = property("app.vendor") ?: "Unknown"
-    val buildDate: String
-        get() = property("app.build-date") ?: "Unknown"
+    val displayName = properties.getProperty("app.display-name") ?: "BrailleBlaster"
+    val description = properties.getProperty("app.description") ?: displayName
+    val version = properties.getProperty("app.version") ?: "Unknown"
+    val vendor = properties.getProperty("app.vendor") ?: "Unknown"
+    val buildDate = properties.getProperty("app.build-date") ?: "Unknown"
     @Suppress("Unused")
-    val fsname: String
-        get() = property("app.fsname") ?: "brailleblaster"
-    val buildHash: String?
-        get() = property("app.build-hash")
+    val fsname = properties.getProperty("app.fsname") ?: "brailleblaster"
+    val buildHash: String? = properties.getProperty("app.build-hash")
     @Suppress("Unused")
-    val vcsUrl: String
-        get() = property("app.vcs-url") ?: "https://github.com/aphtech/brailleblaster"
+    val vcsUrl = properties.getProperty("app.vcs-url") ?: "https://github.com/aphtech/brailleblaster"
     @Suppress("Unused")
-    val downloadUrl: String
-        get() = property("app.site.base-url") ?: "https://github.com/aphtech/brailleblaster/releases/latest"
-    val websiteUrl: String
-        get() = property("app.website-url") ?: "https://www.brailleblaster.org"
+    val downloadUrl = properties.getProperty("app.site.base-url") ?: "https://github.com/aphtech/brailleblaster/releases/latest"
+    val websiteUrl = properties.getProperty("app.website-url") ?: "https://www.brailleblaster.org"
 }

--- a/brailleblaster-core/src/main/java/org/brailleblaster/Main.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/Main.kt
@@ -166,7 +166,6 @@ object Main {
         println(message)
     }
 
-    @JvmStatic
     fun parseStartupArgs(args: Array<String>): StartupArgs {
         val parsed = DefaultParser().parse(startupOptions(), args)
         val positionalArgs = parsed.argList
@@ -180,7 +179,6 @@ object Main {
         )
     }
 
-    @JvmStatic
     fun renderStartupUsage(): String {
         val formatter = HelpFormatter().apply {
             optionComparator = compareBy<Option> { it.opt ?: it.longOpt ?: "" }
@@ -201,7 +199,6 @@ object Main {
         return writer.toString().trimEnd()
     }
 
-    @JvmStatic
     fun renderVersionText(): String = "${Project.BB.displayName} ${Project.BB.version}"
 
     private fun startupOptions(): Options = Options()

--- a/brailleblaster-core/src/main/java/org/brailleblaster/Main.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/Main.kt
@@ -170,7 +170,7 @@ object Main {
         val parsed = DefaultParser().parse(startupOptions(), args)
         val positionalArgs = parsed.argList
         val fileToOpen = positionalArgs.firstOrNull()?.let { Paths.get(it) }
-        val remainingArgs = if (fileToOpen == null) emptyList() else positionalArgs.drop(1)
+        val remainingArgs = positionalArgs.drop(1)
         return StartupArgs(
             fileToOpen = fileToOpen,
             remainingArgs = remainingArgs,

--- a/brailleblaster-core/src/main/java/org/brailleblaster/Main.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/Main.kt
@@ -188,8 +188,8 @@ object Main {
             formatter.printHelp(
                 out,
                 formatter.width,
-                "brailleblaster [options] [input-file]",
-                "Launch BrailleBlaster or print CLI information.",
+                "${AppProperties.fsname} [options] [input-file]",
+                "Launch ${AppProperties.displayName} or print CLI information.",
                 startupOptions(),
                 formatter.leftPadding,
                 formatter.descPadding,
@@ -199,7 +199,7 @@ object Main {
         return writer.toString().trimEnd()
     }
 
-    fun renderVersionText(): String = "${Project.BB.displayName} ${Project.BB.version}"
+    fun renderVersionText(): String = "${AppProperties.displayName} ${AppProperties.version}"
 
     private fun startupOptions(): Options = Options()
         .addOption(Option("h", "help", false, "Show help"))

--- a/brailleblaster-core/src/main/java/org/brailleblaster/Main.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/Main.kt
@@ -15,6 +15,11 @@
  */
 package org.brailleblaster
 
+import org.apache.commons.cli.DefaultParser
+import org.apache.commons.cli.HelpFormatter
+import org.apache.commons.cli.Option
+import org.apache.commons.cli.Options
+import org.apache.commons.cli.ParseException
 import org.brailleblaster.utils.BBData.brailleblasterPath
 import org.brailleblaster.utils.BBData.userDataPath
 import org.brailleblaster.archiver2.ZipHandles
@@ -33,8 +38,11 @@ import org.brailleblaster.utils.braille.singleThreadedMathCAT
 import org.brailleblaster.wordprocessor.WPManager
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
 import java.net.URLClassLoader
 import java.nio.file.Files
+import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.Duration
@@ -53,41 +61,63 @@ import kotlin.system.exitProcess
  * you will get "SWTException: Invalid Thread Access"
  */
 object Main {
+    data class StartupArgs(
+        val fileToOpen: Path?,
+        val remainingArgs: List<String>,
+        val showHelp: Boolean,
+        val showVersion: Boolean,
+    )
+
+    private class StartupCliExitException(val exitCode: Int) : RuntimeException()
+
     var isInitted = false
         private set
 
     @JvmStatic
     fun main(args: Array<String>) {
+        var exitCode = 0
         try {
             start(args)
+        } catch (e: StartupCliExitException) {
+            exitCode = e.exitCode
         } catch (e: Throwable) {
             handleFatalException(e)
+            exitCode = 1
         } finally {
             ZipHandles.closeAll()
         }
-        exitProcess(0)
+        exitProcess(exitCode)
     }
 
     @Throws(Exception::class)
     fun start(args: Array<String>) {
-        val argsToParse = args.toMutableList()
-        var fileToOpen: Path? = null
-        if (argsToParse.isNotEmpty()) {
-            val firstArg = argsToParse[0]
-            try {
-                fileToOpen = Paths.get(firstArg)
-            } catch (e: Exception) {
-                showStartupMessage("Error: The file path '$firstArg' is invalid.")
-                return
-            }
-            if (!Files.exists(fileToOpen)) {
-                val displayName = fileToOpen.fileName?.toString() ?: fileToOpen.toString()
-                showStartupMessage("Error: The file '$displayName' was not found.")
-                return
-            }
-            argsToParse.removeAt(0)
+        val startupArgs = try {
+            parseStartupArgs(args)
+        } catch (e: ParseException) {
+            showStartupMessage("Error: ${e.message}")
+            showStartupMessage(renderStartupUsage())
+            throw StartupCliExitException(2)
+        } catch (e: InvalidPathException) {
+            showStartupMessage("Error: The file path '${e.input}' is invalid.")
+            throw StartupCliExitException(2)
         }
-        initBB(argsToParse)
+
+        if (startupArgs.showHelp) {
+            showStartupMessage(renderStartupUsage())
+            throw StartupCliExitException(0)
+        }
+        if (startupArgs.showVersion) {
+            showStartupMessage(renderVersionText())
+            throw StartupCliExitException(0)
+        }
+
+        val fileToOpen = startupArgs.fileToOpen
+        if (fileToOpen != null && !Files.exists(fileToOpen)) {
+            val displayName = fileToOpen.fileName?.toString() ?: fileToOpen.toString()
+            showStartupMessage("Error: The file '$displayName' was not found.")
+            return
+        }
+        initBB(startupArgs.remainingArgs)
         if (System.getProperty("dumpClassPath", "false") == "true") {
             dumpClassLoader(ClassLoader.getSystemClassLoader())
             //Handle maven-wrapper and presumably other IDE loaders
@@ -95,7 +125,7 @@ object Main {
                 dumpClassLoader(Thread.currentThread().contextClassLoader)
             }
         }
-        if (argsToParse.isNotEmpty()) {
+        if (startupArgs.remainingArgs.isNotEmpty()) {
             LoggerFactory.getLogger(Main::class.java)
                 .error("Unknown extra arguments beyond file: " + args.joinToString(" "))
         }
@@ -135,6 +165,48 @@ object Main {
         }
         println(message)
     }
+
+    @JvmStatic
+    fun parseStartupArgs(args: Array<String>): StartupArgs {
+        val parsed = DefaultParser().parse(startupOptions(), args)
+        val positionalArgs = parsed.argList
+        val fileToOpen = positionalArgs.firstOrNull()?.let { Paths.get(it) }
+        val remainingArgs = if (fileToOpen == null) emptyList() else positionalArgs.drop(1)
+        return StartupArgs(
+            fileToOpen = fileToOpen,
+            remainingArgs = remainingArgs,
+            showHelp = parsed.hasOption("h"),
+            showVersion = parsed.hasOption("v"),
+        )
+    }
+
+    @JvmStatic
+    fun renderStartupUsage(): String {
+        val formatter = HelpFormatter().apply {
+            optionComparator = compareBy<Option> { it.opt ?: it.longOpt ?: "" }
+        }
+        val writer = StringWriter()
+        PrintWriter(writer).use { out ->
+            formatter.printHelp(
+                out,
+                formatter.width,
+                "brailleblaster [options] [input-file]",
+                "Launch BrailleBlaster or print CLI information.",
+                startupOptions(),
+                formatter.leftPadding,
+                formatter.descPadding,
+                ""
+            )
+        }
+        return writer.toString().trimEnd()
+    }
+
+    @JvmStatic
+    fun renderVersionText(): String = "${Project.BB.displayName} ${Project.BB.version}"
+
+    private fun startupOptions(): Options = Options()
+        .addOption(Option("h", "help", false, "Show help"))
+        .addOption(Option("v", "version", false, "Show version"))
 
     /**
      *

--- a/brailleblaster-core/src/main/java/org/brailleblaster/Main.kt
+++ b/brailleblaster-core/src/main/java/org/brailleblaster/Main.kt
@@ -67,55 +67,53 @@ object Main {
         val showHelp: Boolean,
         val showVersion: Boolean,
     )
-
-    private class StartupCliExitException(val exitCode: Int) : RuntimeException()
-
+    // Tracks whether startup initialization has already run; initBB uses this to prevent double initialization in normal runs.
     var isInitted = false
         private set
 
     @JvmStatic
     fun main(args: Array<String>) {
-        var exitCode = 0
+        // Catch startup failures from argument parsing or launch-time exceptions so they can be reported and the app
+        // can exit cleanly; ParseException and InvalidPathException return code 2, and any other throwable returns 1.
         try {
-            start(args)
-        } catch (e: StartupCliExitException) {
-            exitCode = e.exitCode
+            val exitCode = start(args)
+            if (exitCode != 0) {
+                exitProcess(exitCode)
+            }
         } catch (e: Throwable) {
             handleFatalException(e)
-            exitCode = 1
+            exitProcess(1)
         } finally {
             ZipHandles.closeAll()
         }
-        exitProcess(exitCode)
     }
 
-    @Throws(Exception::class)
-    fun start(args: Array<String>) {
+    fun start(args: Array<String>): Int {
         val startupArgs = try {
             parseStartupArgs(args)
         } catch (e: ParseException) {
             showStartupMessage("Error: ${e.message}")
             showStartupMessage(renderStartupUsage())
-            throw StartupCliExitException(2)
+            return 2
         } catch (e: InvalidPathException) {
             showStartupMessage("Error: The file path '${e.input}' is invalid.")
-            throw StartupCliExitException(2)
+            return 2
         }
 
         if (startupArgs.showHelp) {
             showStartupMessage(renderStartupUsage())
-            throw StartupCliExitException(0)
+            return 0
         }
         if (startupArgs.showVersion) {
             showStartupMessage(renderVersionText())
-            throw StartupCliExitException(0)
+            return 0
         }
 
         val fileToOpen = startupArgs.fileToOpen
         if (fileToOpen != null && !Files.exists(fileToOpen)) {
             val displayName = fileToOpen.fileName?.toString() ?: fileToOpen.toString()
             showStartupMessage("Error: The file '$displayName' was not found.")
-            return
+            return 2
         }
         initBB(startupArgs.remainingArgs)
         if (System.getProperty("dumpClassPath", "false") == "true") {
@@ -150,13 +148,15 @@ object Main {
                     WPManager.createInstance(fileToOpen, usageManager).start()
                 } catch (e: BBNotifyException) {
                     showStartupMessage(e.message)
-                    return@use
+                    // @use 0Exits the use block early and reports a normal exit code after showing the warning.
+                    return@use 0
                 }
                 usageManager.logger.logDurationSeconds(tool = BB_TOOL, duration = Duration.between(bbStartTime, Instant.now()))
                 usageManager.logger.logEnd(tool = BB_TOOL, message = runId.toString())
                 usageManager.reportDataAsync().get()
             }
         }
+        return 0
     }
 
     private fun showStartupMessage(message: String?) {

--- a/brailleblaster-core/src/test/java/org/brailleblaster/MainCliParsingTest.kt
+++ b/brailleblaster-core/src/test/java/org/brailleblaster/MainCliParsingTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 American Printing House for the Blind
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.brailleblaster
+
+import org.apache.commons.cli.ParseException
+import org.testng.Assert.assertEquals
+import org.testng.Assert.assertFalse
+import org.testng.Assert.assertTrue
+import org.testng.Assert.expectThrows
+import org.testng.annotations.Test
+import java.nio.file.Files
+
+class MainCliParsingTest {
+    @Test
+    fun parseHelpOption() {
+        val parsed = Main.parseStartupArgs(arrayOf("--help"))
+        assertTrue(parsed.showHelp)
+        assertEquals(parsed.fileToOpen, null)
+    }
+
+    @Test
+    fun parseVersionOption() {
+        val parsed = Main.parseStartupArgs(arrayOf("-v"))
+        assertTrue(parsed.showVersion)
+        assertEquals(parsed.fileToOpen, null)
+    }
+
+    @Test
+    fun parseUnknownOption() {
+        expectThrows(ParseException::class.java) {
+            Main.parseStartupArgs(arrayOf("--not-a-real-option"))
+        }
+    }
+
+    @Test
+    fun parsePositionalInputFile() {
+        val inputFile = Files.createTempFile("bb-main-cli", ".txt")
+        try {
+            val parsed = Main.parseStartupArgs(arrayOf(inputFile.toString()))
+            assertEquals(parsed.fileToOpen, inputFile)
+            assertTrue(parsed.remainingArgs.isEmpty())
+        } finally {
+            Files.deleteIfExists(inputFile)
+        }
+    }
+
+    @Test
+    fun renderVersionTextDoesNotUseUnknownVersion() {
+        assertFalse(Main.renderVersionText().contains("Unknown"))
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,11 @@ child.project.url.inherit.append.path="false">
                 <version>25.0.3</version>
             </dependency>
             <dependency>
+                <groupId>commons-cli</groupId>
+                <artifactId>commons-cli</artifactId>
+                <version>1.11.0</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-collections4</artifactId>
                 <version>4.5.0</version>


### PR DESCRIPTION
Add commons-cli dependency to brailleblaster-core module Replace Main startup ad-hoc parsing with dedicated Commons CLI parser Add -h/--help and -v/--version options with deterministic usage text Keep positional input-file behavior for normal startup flow Return non-zero exit code for unknown/invalid CLI options after printing error + usage Add focused Main CLI parsing tests for help, version, unknown option, and positional file parsing
Issue documented in gitlab issue 69388: 